### PR TITLE
NO-ISSUE: fix scripts for adding new version of operator and add redh…

### DIFF
--- a/Dockerfile.gpu-init-build
+++ b/Dockerfile.gpu-init-build
@@ -7,6 +7,9 @@ RUN curl --retry 5 -sSfL https://raw.githubusercontent.com/golangci/golangci-lin
 
 RUN yum install -y docker && \
     yum clean all
+
+RUN pip3 install PyGithub pyyaml
+
 RUN go get -u golang.org/x/tools/cmd/goimports@v0.0.0-20200520220537-cf2d1e09c845 \
               github.com/onsi/ginkgo/ginkgo@v1.12.2  \
               github.com/golang/mock/mockgen@v1.4.3  \

--- a/hack/gitlab_download.sh
+++ b/hack/gitlab_download.sh
@@ -3,7 +3,7 @@
 GITLAB_API_URL=https://gitlab.com/api/v4
 export GITLAB_TOKEN=${GITLAB_TOKEN:-}
 PROJECT=${PROJECT:-"nvidia/kubernetes/gpu-operator"}
-
+BRANCH=${BRANCH:-"master"}
 PROJECT_ENC=$(echo -n ${PROJECT} | jq -sRr @uri)
 export WORKING_DIR=${WORKING_DIR:-.}
 
@@ -12,7 +12,7 @@ function fetchFile() {
   echo "Fetching file $FILE"
   FILE_ENC=$(echo -n ${FILE} | jq -sRr @uri)
 
-  curl -s --header "PRIVATE-TOKEN: ${GITLAB_TOKEN}" "${GITLAB_API_URL}/projects/${PROJECT_ENC}/repository/files/${FILE_ENC}?ref=master" -o /tmp/file.info
+  curl -s --header "PRIVATE-TOKEN: ${GITLAB_TOKEN}" "${GITLAB_API_URL}/projects/${PROJECT_ENC}/repository/files/${FILE_ENC}?ref=${BRANCH}" -o /tmp/file.info
   if [ "$(dirname $FILE)" != "." ]; then
     mkdir -p $(dirname $FILE)
   fi

--- a/hack/gpu_operator_new_version.py
+++ b/hack/gpu_operator_new_version.py
@@ -13,9 +13,7 @@ MANIFESTS = "manifests"
 ADDON_NAME = "gpu-operator-certified-addon"
 DEPENDENCIES = "metadata/dependencies.yaml"
 ROLE_YAML = os.path.join(MANIFESTS, "gpu-operator_rbac.authorization.k8s.io_v1_role.yaml")
-ROLEBINDING_YAML = os.path.join(MANIFESTS, "gpu-operator_rbac.authorization.k8s.io_v1_rolebinding.yaml")
-CLUSTER_ROLEBINDING_YAML = os.path.join(MANIFESTS, "gpu-operator_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml")
-CSV = os.path.join(MANIFESTS, "gpu-operator.clusterserviceversion.yaml")
+CSV_SUFFIX = "clusterserviceversion.yaml"
 
 ROLES_TO_ADD = [{"apiGroups": ["operators.coreos.com"], "resources": ["clusterserviceversions"],
                  "verbs": ["get", "list"]},
@@ -26,14 +24,23 @@ INIT_CONTAINER = [{"name": "gpu-init-container",
                    "command": ["/usr/bin/init_run"], }]
 
 
+def get_csv_file(bundle_path):
+    manifests = os.path.join(bundle_path, MANIFESTS)
+    for file in os.listdir(manifests):
+        if file.endswith(CSV_SUFFIX):
+            return os.path.join(manifests, file)
+
+
 def handle_csv(bundle_path, version, prev_version):
     print("Handling csv")
-    with open(os.path.join(bundle_path, CSV), "r") as _f:
+    csv_file = get_csv_file(bundle_path)
+    with open(csv_file, "r") as _f:
         csv = yaml.safe_load(_f)
     csv["metadata"]["name"] = f"gpu-operator-certified-addon.v{version}"
     csv["spec"]["replaces"] = f"gpu-operator-certified-addon.v{prev_version}"
     csv["spec"]["install"]["spec"]["deployments"][0]["spec"]["template"]["spec"]["initContainers"] = INIT_CONTAINER
-    with open(os.path.join(bundle_path, CSV), "w") as _f:
+    csv["spec"]["install"]["spec"]["permissions"][0]["rules"].extend(ROLES_TO_ADD)
+    with open(csv_file, "w") as _f:
         yaml.dump(csv, _f)
 
 
@@ -43,38 +50,27 @@ def copy_deps(addon_path, version, prev_version):
                                                                                          f"{version}/{DEPENDENCIES}"))
 
 
-def handle_annotations(bundle_path, channel):
+def handle_annotations(bundle_path, channel, namespace):
     print("Handling annotations")
     with open(os.path.join(bundle_path, ANNOTATION_PATH), "r") as _f:
         annotations = yaml.safe_load(_f)
     annotations["annotations"]["operators.operatorframework.io.bundle.channels.v1"] = channel
     annotations["annotations"]["operators.operatorframework.io.bundle.channel.default.v1"] = channel
     annotations["annotations"]["operators.operatorframework.io.bundle.package.v1"] = ADDON_NAME
+    annotations["annotations"]["operatorframework.io/suggested-namespace"] = namespace
     with open(os.path.join(bundle_path, ANNOTATION_PATH), "w") as _f:
         yaml.dump(annotations, _f)
 
 
-def update_role(bundle_path):
-    print("Updating role")
-    with open(os.path.join(bundle_path, ROLE_YAML), "r") as _f:
-        roles = yaml.safe_load(_f)
-
-    roles["rules"].extend(ROLES_TO_ADD)
-    with open(os.path.join(bundle_path, ROLE_YAML), "w") as _f:
-        yaml.dump(roles, _f)
-
-
-# TODO remove for 1.9.0
-def update_rolebinding_namespaces(bundle_path, namespace):
-    role_files = [ROLEBINDING_YAML, CLUSTER_ROLEBINDING_YAML]
-    print("Setting namespace in %s", role_files)
-    for role_file in role_files:
-        with open(os.path.join(bundle_path, role_file), "r") as _f:
-            roles = yaml.safe_load(_f)
-
-        roles["subjects"][0]["namespace"] = namespace
-        with open(os.path.join(bundle_path, role_file), "w") as _f:
-            yaml.dump(roles, _f)
+def donwload_new_bundle_from_rh_certified(version, addon_path):
+    operators_folder = "operators"
+    gpu_folder = os.path.join(operators_folder, "gpu-operator-certified")
+    current_folder = pathlib.Path(__file__).parent.resolve()
+    subprocess.check_call(f"{current_folder}/github_download.py --org=redhat-openshift-ecosystem "
+                          f"--repo=certified-operators --branch=main "
+                          f"--folder='{gpu_folder}/v{version}' -w {addon_path}"
+                          f" && mv {addon_path}/{gpu_folder}/v{version} {addon_path}/{version} "
+                          f" && rm -rf {addon_path}/{operators_folder}", shell=True)
 
 
 def download_new_bundle(version, addon_path):
@@ -86,11 +82,12 @@ def download_new_bundle(version, addon_path):
 
 def create_new_bundle(args):
     addon_path = os.path.join(args.manage_tenants_bundle_path, ADDON_PATH)
-    download_new_bundle(args.version, addon_path)
+    if args.rh_certified:
+        donwload_new_bundle_from_rh_certified(args.version, addon_path)
+    else:
+        download_new_bundle(args.version, addon_path)
     bundle_path = os.path.join(addon_path, args.version)
-    update_rolebinding_namespaces(bundle_path, args.namespace)
-    update_role(bundle_path)
-    handle_annotations(bundle_path, args.channel)
+    handle_annotations(bundle_path, args.channel, args.namespace)
     handle_csv(bundle_path, args.version, args.prev_version)
     copy_deps(addon_path, args.version, args.prev_version)
 
@@ -102,33 +99,34 @@ if __name__ == '__main__':
     )
     parser.add_argument(
         '-mP', '--manage-tenants-bundle-path',
-        type=str,
         required=True,
         help='Path to managed tenants repo on the disk'
     )
 
     parser.add_argument(
+        '-rh', '--rh-certified',
+        action="store_true",
+        help='Download bundle from redhat certified addon repo'
+    )
+
+    parser.add_argument(
         '-c', '--channel',
-        type=str,
         default="alpha",
         help='Path to managed tenants repo on the disk'
     )
     parser.add_argument(
         '-n', '--namespace',
         default="redhat-gpu-operator",
-        type=str,
         help='Target namespace'
     )
     parser.add_argument(
         '-v', '--version',
         required=True,
-        type=str,
         help='New nvidia version'
     )
     parser.add_argument(
         '-pv', '--prev-version',
         required=True,
-        type=str,
         help='Previous nvidia version'
     )
 


### PR DESCRIPTION
NO-ISSUE: fix scripts for adding new version of operator and add redhat certified operators repo as an option to copy bundle from

Example of usage:
skipper run "hack/gpu_operator_new_version.py -mP /home/itsoiref/work/go/src/github.com/managed-tenants-bundles -rh -c alpha -v 1.9.0-beta -pv 1.8.3"