### PR TITLE
Optimize final image size and rebase on full UBI

### DIFF
--- a/Dockerfile.gpu_init
+++ b/Dockerfile.gpu_init
@@ -1,6 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.16 AS builder
-ENV GOFLAGS=-mod=mod
-WORKDIR /go/src/github.com/openshift/gpu-init-container
+FROM registry.access.redhat.com/ubi8/go-toolset:1.16.12 AS builder
 
 # Bring in the go dependencies before anything else so we can take
 # advantage of caching these layers in future builds.
@@ -11,8 +9,8 @@ RUN go mod download
 COPY . .
 RUN make build
 
-FROM registry.access.redhat.com/ubi8/ubi:latest
+FROM registry.access.redhat.com/ubi8/ubi-micro
 
-COPY --from=builder /go/src/github.com/openshift/gpu-init-container/build/init_container /usr/bin/init_run
+COPY --from=builder /opt/app-root/src/build/init_container /usr/bin/init_run
 
 ENTRYPOINT ["/usr/bin/init_run"]

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ GINKGO_FLAGS = -ginkgo.focus="$(FOCUS)" -ginkgo.v -ginkgo.skip="$(SKIP)" -ginkgo
 all: lint format-check build build-images unit-test
 
 build:
-	CGO_ENABLED=0 go build -o build/init_container main/main.go
+	CGO_ENABLED=0 go build -ldflags="-s -w" -o build/init_container main/main.go
 
 build-images:
 	$(CONTAINER_COMMAND) build $(CONTAINER_BUILD_PARAMS) -f Dockerfile.gpu_init . -t $(INIT)


### PR DESCRIPTION
This change aims at optimizing the final image size.

The first thing it does is to switch to `ubi_/ubi-micro` base
image. This reduces the final image size from 273 MB to 77 MB.

The second thing is to use the `-ldflags="-s -w"` option of
the Go compiler to strip to binary. This reduces the size from
77 MB to 66 MB. In total, the image size is divided by 4.

This change also switches to the `ubi8/go-toolset` base image for the
builder stage. This is the image we recommend to the community and we
don't need all the OpenShift stuff to build a simple Go binary.

Signed-off-by: Fabien Dupont <fabiendupont@pm.me>