### PR TITLE
Cleanup OWNER_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,32 +2,8 @@
 
 aliases:
   code-approvers:
-    - avishayt
     - empovit
-    - eranco74
-    - filanov
-    - gamli75
-    - ori-amizur
-    - oshercc
-    - romfreiman
-    - tsorya
-    - yevgeny-shnaidman
-    - nmagnezi
-    - carbonin
-    - rollandf
-    - danielerez
-    - ybettan
-    - slaviered
-    - osherdp
-    - flaper87
-    - mkowalski
-    - lranjbar
     - sagidayan
     - fabiendupont
     - mresvanis
-  code-reviewers:
-    - jakub-dzon
-    - pkliczewski
-    - masayag
-    - jordigilh
-    - machacekondra
+  code-reviewers: []


### PR DESCRIPTION
This change reduces the list of approvers to people actively working on
the NVIDIA GPU Add-on, in order to reduce noise for others.

Signed-off-by: Fabien Dupont <fabiendupont@pm.me>